### PR TITLE
Potential fix for code scanning alert no. 50: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java
+++ b/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java
@@ -77,8 +77,13 @@ public class ProfileZipSlip extends ProfileUploadBase {
       while (entries.hasMoreElements()) {
         ZipEntry e = entries.nextElement();
         File f = new File(tmpZipDirectory.toFile(), e.getName());
+        // Prevent Zip Slip by validating the output path
+        java.nio.file.Path targetPath = f.toPath().normalize();
+        if (!targetPath.startsWith(tmpZipDirectory)) {
+          throw new IOException("Bad zip entry: " + e.getName());
+        }
         InputStream is = zip.getInputStream(e);
-        Files.copy(is, f.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(is, targetPath, StandardCopyOption.REPLACE_EXISTING);
       }
 
       return isSolved(currentImage, getProfilePictureAsBase64(username));


### PR DESCRIPTION
Potential fix for [https://github.com/VertySi/Testing-Code-QL/security/code-scanning/50](https://github.com/VertySi/Testing-Code-QL/security/code-scanning/50)

To fix the Zip Slip vulnerability, we must ensure that files extracted from the zip archive are only written within the intended extraction directory (`tmpZipDirectory`). This is done by normalizing the output path and verifying that it starts with the intended directory path. Specifically, before writing each file, we should:

1. Construct the output path using the zip entry name.
2. Normalize the output path using `Path.normalize()` (or `File.getCanonicalFile()`).
3. Check that the normalized output path starts with the intended extraction directory path using `Path.startsWith()`.
4. If the check fails, skip extraction of that entry or throw an exception.

The changes should be made in the `processZipUpload` method, specifically in the loop that processes zip entries (lines 77-82). No new methods are needed, but we may need to import `java.nio.file.Path` if not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
